### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/seasaltio/Autoclave.png?branch=master)](https://travis-ci.org/seasaltio/Autoclave)
 [![codecov.io](https://codecov.io/github/seasaltio/Autoclave/coverage.svg?branch=master)](https://codecov.io/github/seasaltio/Autoclave?branch=master)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/Autoclave.svg)](https://img.shields.io/cocoapods/v/Autoclave.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Autoclave.svg)](https://img.shields.io/cocoapods/v/Autoclave.svg)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 Autoclave is your easygoing Autolayout friend. It condenses your constraint definitions into simple chained methods.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
